### PR TITLE
Fix installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,18 @@ Slides to come.
 - composer
 - authbind (use apt-get or brew, it's used so that the user running pm2 can use the `80` port)
 - pm2 (`npm install pm2 -g`)
+- PHP >= 7.1.3 with :
+    - php-sqlite3
+    - php-zip
+    - php-curl
+    - php-amqp
 
 ## Installation
 
 Go to the `front` directory, it's a [Next.js](nextjs.org) project (no reason behind that I just wanted to try their tools).
 Just run `npm install` in there.
 
-Go to the `api` directory and run `make`.
+Go to the `api` directory and run `npm install` and `make`.
 
 ## Launch
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -12,5 +12,5 @@ build: vendor
 frontend:
 	cd ../front/ && npm run build
 
-vendor: composer.json composer.lock
+vendor: composer.json
 	composer install

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -20,3 +20,7 @@ services:
         image: elasticsearch:6.6.1
         ports:
             - "9200:9200"
+        ulimits:
+            nofile:
+                soft: 65536
+                hard: 65536


### PR DESCRIPTION
Hi,

I had multiple errors during the installation : 
1. I had to install 4 missing php extensions visible in the README.
2. The proxy didn't works for me, I had to do this before launch the app : `sudo setcap 'cap_net_bind_service=+ep' /usr/bin/node`
3. I had to change the docker-compose.yml file in order to fix this elasticsearch error : 
`elasticsearch_1  | ERROR: [1] bootstrap checks failed
elasticsearch_1  | [1]: max file descriptors [4096] for elasticsearch process is too low, increase to at least [65536]
`
4. the make command didn't works because the `composer.lock` file was mandatory but the file didn't exist.

